### PR TITLE
Bump OpenFaaS component versions in line with 0.7.8 release

### DIFF
--- a/openfaas/alertmanager-dep.yaml
+++ b/openfaas/alertmanager-dep.yaml
@@ -16,12 +16,12 @@ spec:
     spec:
       containers:
       - name: alertmanager
-        image: prom/alertmanager:v0.9.1
+        image: prom/alertmanager:v0.15.0-rc.0
         imagePullPolicy: Always
         command:
           - alertmanager
-          - -config.file=/alertmanager.yml
-          - -storage.path=/alertmanager
+          - --config.file=/alertmanager.yml
+          - --storage.path=/alertmanager
         ports:
         - containerPort: 9093
           protocol: TCP

--- a/openfaas/gateway-dep.yaml
+++ b/openfaas/gateway-dep.yaml
@@ -30,7 +30,7 @@ spec:
         - name: direct_functions
           value: "true"
         - name: direct_functions_suffix
-          value: "openfaas-fn."
+          value: "openfaas-fn"
         - name: write_timeout
           value: "60s"
         - name: read_timeout

--- a/openfaas/gateway-dep.yaml
+++ b/openfaas/gateway-dep.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: gateway
-        image: functions/gateway:0.7.0
+        image: functions/gateway:0.7.8
         imagePullPolicy: Always
         env:
         - name: faas_prometheus_host
@@ -27,10 +27,16 @@ spec:
           value: "nats.openfaas"
         - name: faas_nats_port
           value: "4222"
+        - name: direct_functions
+          value: "true"
+        - name: direct_functions_suffix
+          value: "openfaas-fn."
         - name: write_timeout
-          value: "60"
+          value: "60s"
         - name: read_timeout
-          value: "60"
+          value: "60s"
+        - name: upstream_timeout 
+          value: "55s"
         ports:
         - containerPort: 8080
           protocol: TCP

--- a/openfaas/netesd-dep.yaml
+++ b/openfaas/netesd-dep.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: faas-controller
       containers:
       - name: faas-netesd
-        image: functions/faas-netesd:0.4.3
+        image: functions/faas-netesd:0.4.6
         imagePullPolicy: Always
         env:
         - name: function_namespace

--- a/openfaas/prometheus-dep.yaml
+++ b/openfaas/prometheus-dep.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: prometheus
-        image: prom/prometheus:v2.1.0
+        image: prom/prometheus:v2.2.0
         imagePullPolicy: Always
         command:
           - prometheus

--- a/openfaas/queue-worker-dep.yaml
+++ b/openfaas/queue-worker-dep.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name:  queue-worker
-        image: functions/queue-worker:0.4.2
+        image: functions/queue-worker:0.4.3
         imagePullPolicy: Always
         env:
         - name: faas_function_suffix


### PR DESCRIPTION
Bumps the following:

| Component    | From       | To                    |
| -------------- | -------- | -------------- |
| gateway          | `0.7.0`   | `0.7.8`             |
| faas-netesd    | `0.4.3`  | `0.4.6`             |
| queue-worker | `0.4.2`  | `0.4.3`             |
| prometheus    | `v2.1.0` | `v2.2.0`           |
| alertmanager  | `v0.9.1` | `v0.15.0-rc.0` |

Also updates config, adding new config to the gateway and changing the command flags in the `alertmanager`.

All seems to work as expected.

![working cluster](https://user-images.githubusercontent.com/83862/38780246-6064f932-40cb-11e8-82b2-1dec7e7997c2.png)
